### PR TITLE
[Windows] handle path separators properly

### DIFF
--- a/cos_utils/upload_files.py
+++ b/cos_utils/upload_files.py
@@ -134,6 +134,9 @@ def do_upload(bucket,
                 else:
                     key = file[len(base_dir)+1:]
 
+                # always use forward slashes in object keys
+                key = key.replace(os.path.sep, '/')
+
                 if prefix:
                     # add key name prefix
                     key = '{}/{}'.format(prefix.rstrip('/'), key)

--- a/cos_utils/upload_files.py
+++ b/cos_utils/upload_files.py
@@ -178,6 +178,9 @@ def do_upload(bucket,
             else:
                 key = file[len(base_dir)+1:]
 
+            # always use forward slashes in object keys
+            key = key.replace(os.path.sep, '/')
+
             if prefix:
                 # add key name prefix
                 key = '{}/{}'.format(prefix.rstrip('/'), key)

--- a/cos_utils/upload_files.py
+++ b/cos_utils/upload_files.py
@@ -114,7 +114,7 @@ def do_upload(bucket,
         if os.path.isdir(pattern):
 
             # source specification identifies a directory
-            base_dir = pattern.rstrip(os.path.sep)
+            base_dir = os.path.abspath(pattern)
 
             if recursive:
                 source_pattern = '**/*'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as readme:
 setup(
   name='cos-utils',
   packages=['cos_utils'],
-  version='0.0.12',
+  version='0.0.13',
   license='Apache-2.0',
   description='Cloud Object Storage utility',
   long_description=README,


### PR DESCRIPTION
On Windows the path separator char is `\`, which needs to be handled properly. Replace 
path separators with `/` in the object key: `d:\\temp\\img.png` => `temp/img.png`